### PR TITLE
Fix character default value typo from "cav-hum-new-mal" to "cav-hum-neu-mal"

### DIFF
--- a/minihack/skills.py
+++ b/minihack/skills.py
@@ -38,7 +38,7 @@ class MiniHackSkill(MiniHack):
         # Perform know steps
         kwargs["allow_all_modes"] = kwargs.pop("allow_all_modes", False)
         # Play with Caveman character by default
-        kwargs["character"] = kwargs.pop("character", "cav-hum-new-mal")
+        kwargs["character"] = kwargs.pop("character", "cav-hum-neu-mal")
         # Default episode limit
         kwargs["max_episode_steps"] = kwargs.pop("max_episode_steps", 250)
 


### PR DESCRIPTION
## Description:
This PR fixes a typo in the default character value assignment. The original code incorrectly used "cav-hum-new-mal" instead of the correct value "cav-hum-neu-mal".