### PR TITLE
Fix typo in weapon wield message

### DIFF
--- a/minihack/reward_manager.py
+++ b/minihack/reward_manager.py
@@ -465,7 +465,7 @@ class RewardManager(AbstractRewardManager):
                 False.
         """
         msgs = [
-            f"{name} wields itself to your hand!",
+            f"{name} welds itself to your hand!",
             f"{name} (weapon in hand)",
         ]
         self._add_message_event(


### PR DESCRIPTION
## Description

Fixed a typo in the weapon wield event message where "wields" was incorrectly used instead of "welds". The message now correctly states that the weapon "welds itself to your hand" rather than "wields itself to your hand". Wielding cursed items didn't result in solving the environment. 

## Changes made
- changed based on the nle [source code](https://github.com/heiner/nle/blob/137abc54076e278ae73c7675f1e396de51e09952/src/wield.c#L170)
```c++
if (will_weld(wep)) {
    const char *tmp = xname(wep), *thestr = "The ";
    if (strncmp(tmp, thestr, 4) && !strncmp(The(tmp), thestr, 4))
        tmp = thestr;
    else
        tmp = "";
    pline("%s%s %s to your %s!", tmp, aobjnam(wep, "weld"),
          (wep->quan == 1L) ? "itself" : "themselves",
          bimanual(wep) ? (const char *) makeplural(body_part(HAND))
                       : body_part(HAND));
    set_bknown(wep, 1);
}
```