### PR TITLE
Replace pkg_resources with importlib.resources

### DIFF
--- a/minihack/base.py
+++ b/minihack/base.py
@@ -5,7 +5,7 @@ import subprocess
 import random
 import gymnasium as gym
 import numpy as np
-import pkg_resources
+from importlib.resources import files
 from typing import Tuple
 
 from nle import _pynethack, nethack
@@ -17,10 +17,7 @@ from minihack.tiles import GlyphMapper
 
 PATH_DAT_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "dat")
 LIB_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "lib")
-PATCH_SCRIPT = os.path.join(
-    pkg_resources.resource_filename("minihack", "scripts"),
-    "mh_patch_nhdat.sh",
-)
+PATCH_SCRIPT = files("minihack.scripts").joinpath("mh_patch_nhdat.sh")
 MH_FULL_ACTIONS = list(FULL_ACTIONS)
 try:
     MH_FULL_ACTIONS.remove(nethack.MiscDirection.UP)
@@ -38,7 +35,7 @@ try:
     )
 except AttributeError:
     NLE_EXTRA_V081_ACTIONS = ()
-HACKDIR = pkg_resources.resource_filename("nle", "nethackdir")
+HACKDIR = files("nle").joinpath("nethackdir")
 
 RGB_MAX_VAL = 255
 N_TILE_PIXEL = 16

--- a/minihack/base.py
+++ b/minihack/base.py
@@ -5,7 +5,7 @@ import subprocess
 import random
 import gymnasium as gym
 import numpy as np
-from importlib.resources import files
+from importlib_resources import files
 from typing import Tuple
 
 from nle import _pynethack, nethack

--- a/minihack/envs/boxohack.py
+++ b/minihack/envs/boxohack.py
@@ -3,7 +3,7 @@ import os
 import random
 
 import numpy as np
-from importlib.resources import files
+from importlib_resources import files
 from nle import nethack
 from minihack.envs import register
 from minihack import LevelGenerator, MiniHackNavigation

--- a/minihack/envs/boxohack.py
+++ b/minihack/envs/boxohack.py
@@ -3,15 +3,12 @@ import os
 import random
 
 import numpy as np
-import pkg_resources
+from importlib.resources import files
 from nle import nethack
 from minihack.envs import register
 from minihack import LevelGenerator, MiniHackNavigation
 
-LEVELS_PATH = os.path.join(
-    pkg_resources.resource_filename("minihack", "dat"),
-    "boxoban-levels-master",
-)
+LEVELS_PATH = files("minihack.dat").joinpath("boxoban-levels-master")
 # The agent can only move towards 4 cardinal directions (instead of default 8)
 MOVE_ACTIONS = tuple(nethack.CompassCardinalDirection)
 

--- a/minihack/scripts/download_boxoban_levels.py
+++ b/minihack/scripts/download_boxoban_levels.py
@@ -2,7 +2,7 @@
 
 import os
 import zipfile
-from importlib.resources import files
+from importlib_resources import files
 
 DESTINATION_PATH = files("minihack.dat")
 BOXOBAN_REPO_URL = (

--- a/minihack/scripts/download_boxoban_levels.py
+++ b/minihack/scripts/download_boxoban_levels.py
@@ -2,9 +2,9 @@
 
 import os
 import zipfile
-import pkg_resources
+from importlib.resources import files
 
-DESTINATION_PATH = pkg_resources.resource_filename("minihack", "dat")
+DESTINATION_PATH = files("minihack.dat")
 BOXOBAN_REPO_URL = (
     "https://github.com/deepmind/boxoban-levels/archive/refs/heads/master.zip"
 )

--- a/minihack/scripts/get_nhwiki_data.sh
+++ b/minihack/scripts/get_nhwiki_data.sh
@@ -1,6 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
-DATA_DIR=$(python -c 'from importlib.resources import files; print(files("nle").joinpath("minihack").joinpath("dat"), end="")')
+DATA_DIR=$(python -c 'from importlib_resources import files; print(files("nle").joinpath("minihack").joinpath("dat"), end="")')
 
 wget https://www.dropbox.com/s/6qbfmsr3l89sip0/nethackwikidata.json
 

--- a/minihack/scripts/get_nhwiki_data.sh
+++ b/minihack/scripts/get_nhwiki_data.sh
@@ -1,6 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
-DATA_DIR=$(python -c 'import pkg_resources; print(pkg_resources.resource_filename("nle", "minihack/dat"), end="")')
+DATA_DIR=$(python -c 'from importlib.resources import files; print(files("nle").joinpath("minihack").joinpath("dat"), end="")')
 
 wget https://www.dropbox.com/s/6qbfmsr3l89sip0/nethackwikidata.json
 

--- a/minihack/tiles/glyph_mapper.py
+++ b/minihack/tiles/glyph_mapper.py
@@ -3,7 +3,7 @@
 from minihack.tiles import glyph2tile, MAXOTHTILE
 from nle.nethack import MAX_GLYPH
 import numpy as np
-import pkg_resources
+from importlib.resources import files
 import pickle
 import os
 
@@ -19,10 +19,7 @@ class GlyphMapper:
         If it doesn't, call make_tiles.py in win/
         """
 
-        tile_rgb_path = os.path.join(
-            pkg_resources.resource_filename("minihack", "tiles"),
-            "tiles.pkl",
-        )
+        tile_rgb_path = files("minihack.tiles").joinpath("tiles.pkl")
 
         return pickle.load(open(tile_rgb_path, "rb"))
 

--- a/minihack/tiles/glyph_mapper.py
+++ b/minihack/tiles/glyph_mapper.py
@@ -3,7 +3,7 @@
 from minihack.tiles import glyph2tile, MAXOTHTILE
 from nle.nethack import MAX_GLYPH
 import numpy as np
-from importlib.resources import files
+from importlib_resources import files
 import pickle
 import os
 

--- a/minihack/wiki.py
+++ b/minihack/wiki.py
@@ -8,7 +8,7 @@ from functools import lru_cache
 from typing import List
 from urllib.parse import unquote
 
-import pkg_resources
+from importlib.resources import files
 
 try:
     import inflect
@@ -20,7 +20,7 @@ except ImportError as error:  # noqa
     PREPROCESSING_ALLOWED = False
     import_error = error
 
-DATA_DIR_PATH = pkg_resources.resource_filename("nle", "minihack/dat")
+DATA_DIR_PATH = files("nle").joinpath("minihack").joinpath("dat")
 
 EXCEPTIONS = (
     "floor of a room",

--- a/minihack/wiki.py
+++ b/minihack/wiki.py
@@ -8,7 +8,7 @@ from functools import lru_cache
 from typing import List
 from urllib.parse import unquote
 
-from importlib.resources import files
+from importlib_resources import files
 
 try:
     import inflect

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,12 @@ entry_points = {
     ]
 }
 
-install_requires = ["numpy>=1.16", "gymnasium", "setuptools"]
+install_requires = [
+    "numpy>=1.16",
+    "gymnasium",
+    "setuptools",
+    "importlib-resources",
+]
 if not os.getenv("READTHEDOCS"):
     install_requires.append("nle")
 


### PR DESCRIPTION
This resolves "UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81".

Note: importlib.resources requires Python ≥3.7, same as MiniHack (see [setup.py](https://github.com/samvelyan/minihack/blob/00c58529c9f8f0dcc1de80560efc036e67883af5/setup.py#L121)).

EDIT: It turns out that importlib.resources.files requires Python ≥3.9 so the next best thing is to use its backport `importlib-resources`, which adds an extra dependency.